### PR TITLE
Add some error checking

### DIFF
--- a/samp-map-parser.inc
+++ b/samp-map-parser.inc
@@ -469,6 +469,8 @@ static stock ProcessRemovedBuildings(playerid)
 		new bool:endremove = false;
 	#endif
 
+	if(!pool_valid(Maps)) Maps = pool_new();
+
 	for(new Iter:i = pool_iter(Maps), map[MAP_DATA]; iter_inside(i); iter_move_next(i))
 	{
 		#if PREVENT_REMOVE_BUILDING_CRASH == 1

--- a/samp-map-parser.inc
+++ b/samp-map-parser.inc
@@ -292,6 +292,8 @@ stock GetMapCount()
 
 stock GetMapList(String:string, bool:order = false)
 {
+	if(!pool_valid(Maps)) Maps = pool_new();
+
 	str_append_format(string, "Slot\tMap Name\tObjects\n");
 	if(order)
 	{
@@ -332,6 +334,13 @@ stock IsValidMapFile(const mapname[])
 
 stock ExportMap(mapid)
 {
+	if(!pool_valid(Maps)) Maps = pool_new();
+
+	if(!pool_has(Maps, mapid)) {
+		printf("[MAP PARSER] Unable to export map id %d. Invalid id.", id);
+		return false;
+	}
+	
 	new mapname[MAX_MAP_NAME], templine[256];
 	format(mapname, MAX_MAP_NAME, "%s%s", GetMapName(mapid), MAP_FILE_EXTENSION);
 	if(file_exists(mapname)) file_delete(mapname);


### PR DESCRIPTION
Add some error checking to avoid possible errors. At least the ones I've encountered so far.

If we invoked those functions without creating objects first, it would result in a run time error.