### PR TITLE
Make python converter more flexible with maps

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -1,4 +1,5 @@
 import os
+import re 
 path = os.getcwd()
 
 
@@ -63,10 +64,8 @@ def convert():
 
     for line in input:
         if line.find('CreateDynamicObject(') != -1:
-            line = line.replace('tmpobjid = CreateDynamicObject(', '')
-            line = line.replace('CreateDynamicObject(', '')
-            line = line.replace(');\n', '')
-            line = line.replace('); \n', '')
+            line = re.sub('^.*CreateDynamicObject\(', '', line)
+            line = re.sub('\);(w+)?', '', line)
             params = line.split(', ')
 
             object = samp_object()
@@ -77,13 +76,15 @@ def convert():
             object.rx = float(params[4])
             object.ry = float(params[5])
             object.rz = float(params[6])
-            object.worldid = newworldid if newworldid != -5 else (-1 if params[7] is None else int(params[7]))
+            try:
+                object.worldid = newworldid if newworldid != -5 else (-1 if params[7] is None else int(params[7]))
+            except IndexError:
+                object.worldid = newworldid if newworldid != -5 else -1
 
             objects.append(object)
         elif line.find('SetDynamicObjectMaterial(') != -1:
-            line = line.replace('SetDynamicObjectMaterial(', '')
-            line = line.replace(');\n', '')
-            line = line.replace('tmpobjid,', '')
+            line = re.sub('^.*SetDynamicObjectMaterial\(([^,]+),', '', line)
+            line = re.sub('\);(w+)?', '', line)
             params = line.split(', ')
 
             material = samp_object_material()
@@ -111,9 +112,8 @@ def convert():
             object = objects[len(objects) - 1]
             object.materials.append(material)
         elif line.find('SetDynamicObjectMaterialText(') != -1:
-            line = line.replace('SetDynamicObjectMaterialText(', '')
-            line = line.replace(');\n', '')
-            line = line.replace('tmpobjid,', '')
+            line = re.sub('^.*SetDynamicObjectMaterialText\(([^,]+),', '', line)
+            line = re.sub('\);(w+)?', '', line)
             params = line.split(', ')
 
             if len(params) != 9:

--- a/converter.py
+++ b/converter.py
@@ -44,12 +44,24 @@ class samp_object():
     ry: float
     rz: float
     worldid: int
+    interior: int
+    player: int
+    streamdist: float
+    drawdist: float
+    areaid: int
+    priority: int
     materials: list
     materialtext: list
     isdoor: bool
 
 
 newworldid = -1
+interior = -1
+player = -1
+streamdist = 300.0
+drawdist = 300.0
+areaid = -1
+priority = 0
 mapname = ""
 
 
@@ -80,6 +92,13 @@ def convert():
                 object.worldid = newworldid if newworldid != -5 else (-1 if params[7] is None else int(params[7]))
             except IndexError:
                 object.worldid = newworldid if newworldid != -5 else -1
+
+            object.interior = interior if len(params) <= 8 else int(params[8])
+            object.player = interior if len(params) <= 9 else int(params[9])
+            object.streamdist = streamdist if len(params) <= 10 else float(params[10])
+            object.drawdist = drawdist if len(params) <= 11 else float(params[11])
+            object.areaid = areaid if len(params) <= 12 else int(params[12])
+            object.priority = priority if len(params) <= 13 else int(params[13])
 
             objects.append(object)
         elif line.find('SetDynamicObjectMaterial(') != -1:
@@ -161,7 +180,7 @@ def convert():
         output.write(f'rmv {building.remove_modelid} {building.remove_x:.6f} {building.remove_y:.6f} {building.remove_z:.6f} {building.remove_radius:.2f}\n')
 
     for object in objects:
-        output.write(f'{object.modelid} {object.x:.6f} {object.y:.6f} {object.z:.6f} {object.rx:.6f} {object.ry:.6f} {object.rz:.6f} {object.worldid}\n')
+        output.write(f'{object.modelid} {object.x:.6f} {object.y:.6f} {object.z:.6f} {object.rx:.6f} {object.ry:.6f} {object.rz:.6f} {object.worldid} {object.interior} {object.player} {object.streamdist:.6f} {object.drawdist:.6f} {object.areaid} {object.priority}\n')
 
         if len(object.materials) > 0:
             for material in object.materials:


### PR DESCRIPTION
With this PR we aren't restricted to using only `tmpobjid` as the object variable and `\n` for the line endings at the cost of importing a regex library.

Also, world id is an optional parameter and some mapping tools export maps without it. This change patches it as well by using try&catch.