### PR TITLE
Add a safety check in GetMapNameFromID

### DIFF
--- a/samp-map-parser.inc
+++ b/samp-map-parser.inc
@@ -267,6 +267,11 @@ stock ReprocessMaps()
 
 stock GetMapNameFromID(mapid)
 {
+	if (!pool_valid(Maps))
+  	{
+		return INVALID_MAP_ID;
+	}
+
 	new mapname[MAX_MAP_NAME];
 	if(!pool_valid(Maps) || mapid < 0 || !pool_has(Maps, mapid))
 	{


### PR DESCRIPTION
If we attempt to use the function despite not having any map already loaded, we'll get an error