### PR TITLE
Fix sanity check (wrong function) and stop returning prints

### DIFF
--- a/samp-map-parser.inc
+++ b/samp-map-parser.inc
@@ -267,11 +267,6 @@ stock ReprocessMaps()
 
 stock GetMapNameFromID(mapid)
 {
-	if (!pool_valid(Maps))
-  	{
-		return INVALID_MAP_ID;
-	}
-
 	new mapname[MAX_MAP_NAME];
 	if(!pool_valid(Maps) || mapid < 0 || !pool_has(Maps, mapid))
 	{
@@ -288,6 +283,11 @@ stock GetMapNameFromID(mapid)
 
 stock GetMapIDFromName(const name[])
 {
+	if (!pool_valid(Maps))
+	{
+		return INVALID_MAP_ID;
+	}
+
 	if(IsNumeric(name))
 	{
 		new mapid = strval(name);

--- a/samp-map-parser.inc
+++ b/samp-map-parser.inc
@@ -128,7 +128,8 @@ stock ProcessMaps()
 
 stock LoadMap(mapname[])
 {
-	if(strlen(mapname) > MAX_MAP_NAME) {
+	if(strlen(mapname) > MAX_MAP_NAME)
+	{
 		printf("[MAP PARSER] Map name '%s' is too long.", mapname);
 		return INVALID_MAP_ID;
 	}
@@ -138,7 +139,8 @@ stock LoadMap(mapname[])
 	format(map[MapName], MAX_MAP_NAME, mapname);
 
 	new mapid = GetMapIDFromName(map[MapName]);
-	if(mapid != INVALID_MAP_ID) {
+	if(mapid != INVALID_MAP_ID)
+	{
 		printf("[MAP PARSER] Attempted to load map '%s' while it was already loaded.", mapname);
 		return mapid;
 	}

--- a/samp-map-parser.inc
+++ b/samp-map-parser.inc
@@ -128,13 +128,20 @@ stock ProcessMaps()
 
 stock LoadMap(mapname[])
 {
-	if(strlen(mapname) > MAX_MAP_NAME) return printf("[MAP PARSER] Map name '%s' is too long.", mapname);
+	if(strlen(mapname) > MAX_MAP_NAME) {
+		printf("[MAP PARSER] Map name '%s' is too long.", mapname);
+		return INVALID_MAP_ID;
+	}
 
 	new map[MAP_DATA];
 	strreplace(mapname, MAP_FILE_EXTENSION, "", false, 0, -1, MAX_MAP_NAME);
 	format(map[MapName], MAX_MAP_NAME, mapname);
 
-	if(GetMapIDFromName(map[MapName]) != INVALID_MAP_ID) return printf("[MAP PARSER] Attempted to load map '%s' while it was already loaded.", mapname);
+	new mapid = GetMapIDFromName(map[MapName]);
+	if(mapid != INVALID_MAP_ID) {
+		printf("[MAP PARSER] Attempted to load map '%s' while it was already loaded.", mapname);
+		return mapid;
+	}
 
 	if(!pool_valid(Maps))
 	{


### PR DESCRIPTION
I must've accidentally added the sanity check in the last PR to a wrong function, most likely due to doing it via the Github interface. 
This pull requests:
- Fixes my mistake, I moved the check down to the correct function
- Makes it so instead of returning the value of `printf`, we return useful data in the `LoadMap` function